### PR TITLE
Allow the URL to be specified as a query parameter

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -147,7 +147,7 @@ var onSaxonLoad = function() {
       var matches = document.location.search.match(/[\?&]url=([^&]+)/);
 
       if (matches) {
-          $('#jats_url').val(matches[1]).trigger('change');
+          $('#jats_url').val(decodeURIComponent(matches[1])).trigger('change');
       }
     });
 

--- a/validate.js
+++ b/validate.js
@@ -143,6 +143,12 @@ var onSaxonLoad = function() {
 
       // Ready to go
       results.reset();
+
+      var matches = document.location.search.match(/[\?&]url=([^&]+)/);
+
+      if (matches) {
+          $('#jats_url').val(matches[1]).trigger('change');
+      }
     });
 
 


### PR DESCRIPTION
e.g. http://jats4r.org/validator/?url=https://peerj.com/articles/100.xml
