### PR TITLE
python dependency installation after venv activated

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -15,9 +15,9 @@ export JATS4R_HOME=`pwd`
 # Create virtualenv if needed; and activate it
 if ! [ -f env/bin/activate ]; then
   virtualenv -p python3 env
-  pip install -r requirements.txt
 fi
 . env/bin/activate
+pip install -r requirements.txt
 
 export DTDANALYZER_HOME=$JATS4R_HOME/lib/DtdAnalyzer-0.5
 export SAXON_JAR=$DTDANALYZER_HOME/lib/saxon9he.jar


### PR DESCRIPTION
`virtualenv` doesn't activate the virtual environment after creation, so initial installation will fail. the `pip install  ...` command has been shifted after activation. this has the effect of always installing the requirements file, however the number of requirements are few and their sizes are small and they are skipped if already installed - the overhead would be minimal.
